### PR TITLE
fix: support custom deployed lambda names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ class ServerlessOfflineSQSExternal {
     const lambda = new Lambda(lambdaConfig);
 
     const params = {
-      FunctionName: `${this.service.service}-${this.service.provider.stage}-${functionName}`,
+      FunctionName: func.name,
       InvocationType: 'Event',
       Payload: JSON.stringify(event),
     };
@@ -260,7 +260,7 @@ class ServerlessOfflineSQSExternal {
 
       if (!isEmpty(queues)) {
         printBlankLine();
-        this.serverless.cli.log(`SQS for ${functionName}:`);
+        this.serverless.cli.log(`SQS for ${functionName} (exposed as ${_function.name}):`);
       }
 
       queues.forEach((queueEvent) => {


### PR DESCRIPTION
Lambda definitions can have an explicit deployed lambda name in order to override the default serverless framework naming convention (`service-stage-lambda_name`).
Per the [docs](https://www.serverless.com/framework/docs/providers/aws/guide/functions/):
```
# serverless.yml
service: myService
...
functions:
  hello:
    handler: handler.hello # required, handler set in AWS Lambda
    name: ${sls:stage}-lambdaName # optional, Deployed Lambda name
    ...
```

When this option is set, the current SQS-external plugin code ignores it and attempts to generate a function name that matches the default convention. In the above example, it would attempt to pass something like `myService-prod-lambdaName` to the invoker rather than the customized `prod-lambdaName`. That serverless-offline invocation will fail to find the matching lambda, since it's keyed off of the customized name.

serverless-offline will log the exposed names at startup:
```
offline: Offline [http for lambda] listening on http://localhost:3002
offline: Function names exposed for local invocation by aws-sdk:
           * lambdaName: prod-lambdaName
```
This PR always passes the logical function name to the offline invoker; that matches the current behavior for any lambda that hasn't set a name. It also logs the deployed lambda name at startup for convenience.