### PR TITLE
add changelog and bump version to 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [1.0.7](https://github.com/vuongngo/serverless-offline-sqs-external/tree/HEAD)
+
+Bug Fixes:
+
+* fix: support custom deployed lambda names [\#2](https://github.com/vuongngo/serverless-offline-sqs-external/pull/2)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-offline-sqs-external",
-  "version": "1.0.4",
-  "description": "Emulate AWS Lambda ans SQS locally by listening to external SQS",
+  "version": "1.0.7",
+  "description": "Emulate AWS Lambda and SQS locally by listening to external SQS",
   "main": "dist",
   "files": [
     "dist/index.js",


### PR DESCRIPTION
npm has a 1.0.6 version even though package.json is at 1.0.4, so skipping to match